### PR TITLE
Fix corruption exception in StaticSaliencySpectralResidual

### DIFF
--- a/modules/saliency/src/staticSaliencySpectralResidual.cpp
+++ b/modules/saliency/src/staticSaliencySpectralResidual.cpp
@@ -109,7 +109,7 @@ bool StaticSaliencySpectralResidual::computeSaliencyImpl( InputArray image, Outp
 
   //-- Get magnitude and phase of frequency spectrum --//
   cartToPolar( mv.at( 0 ), mv.at( 1 ), magnitude, angle, false );
-  log( magnitude, logAmplitude );
+  log( magnitude + Scalar( 1 ), logAmplitude );
   //-- Blur log amplitude with averaging filter --//
   blur( logAmplitude, logAmplitude_blur, Size( 3, 3 ), Point( -1, -1 ), BORDER_DEFAULT );
 

--- a/modules/saliency/test/test_main.cpp
+++ b/modules/saliency/test/test_main.cpp
@@ -1,0 +1,41 @@
+/*
+By downloading, copying, installing or using the software you agree to this
+license. If you do not agree to this license, do not download, install,
+copy or use the software.
+
+                          License Agreement
+               For Open Source Computer Vision Library
+                       (3-clause BSD License)
+
+Copyright (C) 2013, OpenCV Foundation, all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the names of the copyright holders nor the names of the contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are
+disclaimed. In no event shall copyright holders or contributors be liable for
+any direct, indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+
+#include "test_precomp.hpp"
+
+CV_TEST_MAIN("cv")

--- a/modules/saliency/test/test_precomp.hpp
+++ b/modules/saliency/test/test_precomp.hpp
@@ -1,0 +1,14 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#ifndef __OPENCV_TEST_PRECOMP_HPP__
+#define __OPENCV_TEST_PRECOMP_HPP__
+
+#include "opencv2/ts.hpp"
+#include "opencv2/saliency.hpp"
+
+namespace opencv_test {
+    using namespace saliency;
+}
+
+#endif

--- a/modules/saliency/test/test_static_saliency_spectral_residual.cpp
+++ b/modules/saliency/test/test_static_saliency_spectral_residual.cpp
@@ -1,0 +1,53 @@
+/*
+By downloading, copying, installing or using the software you agree to this
+license. If you do not agree to this license, do not download, install,
+copy or use the software.
+
+                          License Agreement
+               For Open Source Computer Vision Library
+                       (3-clause BSD License)
+
+Copyright (C) 2013, OpenCV Foundation, all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the names of the copyright holders nor the names of the contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are
+disclaimed. In no event shall copyright holders or contributors be liable for
+any direct, indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+TEST(CV_StaticSaliencySpectralResidual, should_not_contain_nan)
+{
+    Ptr<StaticSaliencySpectralResidual> saliencyAlgorithm = StaticSaliencySpectralResidual::create();
+    Mat img = Mat::zeros(cv::Size(1, 1), CV_32F);
+    Mat saliencyMap;
+
+    saliencyAlgorithm->computeSaliency(img, saliencyMap);
+    EXPECT_FALSE(std::isnan(saliencyMap.at<float>(0, 0)));
+}
+
+}} // namespace


### PR DESCRIPTION
In some case, Discrete Fourier Transform in computeSaliencyImpl() returns
magnitude matrix which contains zero values.
Then, log() returns -inf values and normalization with blur() returns -nan.
When computeBinaryMap() is called double free or corruption exception occurs
because kmeans() fails to compute distance.

resolves #1673

### This pullrequest changes

Scalar( 1 ) is added to magnitude matrix in computeSaliencyImpl() to avoid -inf value after log() on zero value.